### PR TITLE
filter empty string in config urls

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/sources/URLConfigurationSource.java
+++ b/archaius-core/src/main/java/com/netflix/config/sources/URLConfigurationSource.java
@@ -160,6 +160,8 @@ public class URLConfigurationSource implements PolledConfigurationSource {
         String[] fileNames;
         if (name != null) {
             fileNames = name.split(",");
+            // filter out empty string in the middle
+            fileNames = Arrays.stream(fileNames).filter(s -> !s.isEmpty()).toArray(String[]::new);
         } else {
             fileNames = new String[0];
         }


### PR DESCRIPTION
Filter out empty string in the middle of config urls, when will cause load config failed behind it.